### PR TITLE
Make RTC traits more usable in dyn contexts

### DIFF
--- a/embedded-mcu-hal/src/nvram.rs
+++ b/embedded-mcu-hal/src/nvram.rs
@@ -1,7 +1,7 @@
 //! Traits for NVRAM (Non-Volatile Random Access Memory) storage and management.
 
 /// An individual NVRAM storage cell.
-pub trait NvramStorage<'a, T> {
+pub trait NvramStorage<'a, T>: Send {
     /// Reads the value from the NVRAM storage cell.
     fn read(&self) -> T;
 
@@ -11,7 +11,7 @@ pub trait NvramStorage<'a, T> {
 
 /// Trait for a collection of individually-addressable NVRAM storage cells.
 /// StoredType is typically the word size of the platform CPU (e.g. u32).
-pub trait Nvram<'a, StorageType, StoredType, const CELL_COUNT: usize>
+pub trait Nvram<'a, StorageType, StoredType, const CELL_COUNT: usize>: Send
 where
     StorageType: NvramStorage<'a, StoredType>,
 {

--- a/embedded-mcu-hal/src/time/datetime_clock.rs
+++ b/embedded-mcu-hal/src/time/datetime_clock.rs
@@ -18,7 +18,7 @@ pub enum DatetimeClockError {
 /// Trait for datetime-based clock (e.g. real-time clock).
 /// This trait provides methods to get and set the current wall-clock date and time in a structured format.
 /// Typical usage would be setting the current UTC time, periodically syncing it with an external time source (e.g. host OS with NTP daemon) to account for leap seconds.
-pub trait DatetimeClock {
+pub trait DatetimeClock: Send {
     /// Returns the current structured date and time.
     fn get_current_datetime(&self) -> Result<Datetime, DatetimeClockError>;
 
@@ -26,6 +26,6 @@ pub trait DatetimeClock {
     /// If a Datetime with greater precision than MAX_RESOLUTION_HZ is provided, it will be truncated to the maximum resolution.
     fn set_current_datetime(&mut self, datetime: &Datetime) -> Result<(), DatetimeClockError>;
 
-    /// The resolution of the RTC in Hz.  Typical values are 1hz and 1000hz.
-    const MAX_RESOLUTION_HZ: u32;
+    /// Returns the resolution of the RTC in Hz.  Typical values are 1hz and 1000hz.
+    fn max_resolution_hz(&self) -> u32;
 }


### PR DESCRIPTION
Currently, the RTC traits are not easily usable in dyn contexts.  The DatetimeClock trait has an associated constant, which is inherently not dyn-safe, and all the traits do not have Send as a supertrait, which means that attempting to use them in static dyn contexts requires specifying `T + Send` everywhere.

I believe there are no reasonable implementations of these traits that are not Send, so this change adds that as a supertrait to all HAL traits and changes DatetimeClock to use a member function rather than an associated constant.