### PR TITLE
embedded-mcu-hal: remove defmt as default feature

### DIFF
--- a/embedded-mcu-hal/Cargo.toml
+++ b/embedded-mcu-hal/Cargo.toml
@@ -10,7 +10,7 @@ chrono = { version = "^0.4", default-features = false, optional = true }
 defmt = { version = "1.0", optional = true }
 
 [features]
-default = ["defmt"]
+default = []
 
 chrono = ["dep:chrono"]
 defmt = ["dep:defmt"]


### PR DESCRIPTION
Remove defmt as a default feature on embedded-mcu-hal to make life easier for clients: https://github.com/OpenDevicePartnership/embassy-imxrt/pull/483