### PR TITLE
Remove Send supertrait from NvramStorage, Nvram, and DatetimeClock

### DIFF
--- a/embedded-mcu-hal/src/nvram.rs
+++ b/embedded-mcu-hal/src/nvram.rs
@@ -1,7 +1,7 @@
 //! Traits for NVRAM (Non-Volatile Random Access Memory) storage and management.
 
 /// An individual NVRAM storage cell.
-pub trait NvramStorage<'a, T>: Send {
+pub trait NvramStorage<'a, T> {
     /// Reads the value from the NVRAM storage cell.
     fn read(&self) -> T;
 
@@ -11,7 +11,7 @@ pub trait NvramStorage<'a, T>: Send {
 
 /// Trait for a collection of individually-addressable NVRAM storage cells.
 /// StoredType is typically the word size of the platform CPU (e.g. u32).
-pub trait Nvram<'a, StorageType, StoredType, const CELL_COUNT: usize>: Send
+pub trait Nvram<'a, StorageType, StoredType, const CELL_COUNT: usize>
 where
     StorageType: NvramStorage<'a, StoredType>,
     StoredType: Copy,

--- a/embedded-mcu-hal/src/time/datetime_clock.rs
+++ b/embedded-mcu-hal/src/time/datetime_clock.rs
@@ -18,7 +18,7 @@ pub enum DatetimeClockError {
 /// Trait for datetime-based clock (e.g. real-time clock).
 /// This trait provides methods to get and set the current wall-clock date and time in a structured format.
 /// Typical usage would be setting the current UTC time, periodically syncing it with an external time source (e.g. host OS with NTP daemon) to account for leap seconds.
-pub trait DatetimeClock: Send {
+pub trait DatetimeClock {
     /// Returns the current structured date and time.
     fn get_current_datetime(&self) -> Result<Datetime, DatetimeClockError>;
 


### PR DESCRIPTION
The Send bound was present on NvramStorage, Nvram, and DatetimeClock as supertraits, requiring every concrete implementation of those traits to be Send. This constraint has been removed.

Rationale
---------

HAL traits define *what a peripheral does*, not *how it participates in a concurrency model*. `Send` is a concurrency concern and is orthogonal to the behavioral contract these traits express. Conflating the two violates the single-responsibility principle at the trait design level.

`embedded-hal`, the established precedent for Rust embedded HAL crates, does not place `Send` bounds on any of its traits for exactly this reason.  Callers that need `Send` add it at the use site (e.g. T: DatetimeClock + Send), which is expressive and costs nothing. Baking it into the trait takes that choice away from the implementor.

Concretely, a `Send` supertrait:

  1. Silently bans valid implementations.

     Peripheral drivers that use `Rc`, `Cell`, or interrupt-local state internally are not `Send` by definition. Those drivers are perfectly correct on single-core, single-threaded targets -- which represent a large fraction of the MCUs this crate targets.

  2. Creates an asymmetric API surface.

     `Watchdog` never carried a `Send` bound; `NvramStorage`, `Nvram`, and `DatetimeClock` did. There was no documented reason for the inconsistency, and it was confusing.

  3. Is a semver-breaking change to remove once published.

     Adding a supertrait bound is easy; removing one breaks every caller that relied on trait objects or where-clauses that only mention the trait. The conservative choice is to omit the bound and let callers opt in.

Migration
---------

Code that previously relied on the implicit `Send` guarantee can restore the same constraint locally:

  fn my_fn<C: DatetimeClock + Send>(clock: C) { ... }

This is identical in effect and makes the threading requirement visible at the call site, which is where it belongs.