### PR TITLE
Prepare embedded-mcu-hal v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ dependencies = [
 
 [[package]]
 name = "embedded-mcu-hal"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "defmt 1.0.1",

--- a/embedded-mcu-hal/Cargo.toml
+++ b/embedded-mcu-hal/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "embedded-mcu-hal"
 description = "Traits used by Open Device Partnership's Embedded Controller project"
-version = "0.2.0"
+version = "0.3.0"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bumps `embedded-mcu-hal` from `0.2.0` to `0.3.0` and refreshes `Cargo.lock`.

This is a **minor** release: all changes since `v0.2.0` are additive. `cargo semver-checks check-release` confirms no breaking changes (196 checks pass).

## What's new since v0.2.0

### New traits
- **SMBus HAL** (#7) — adds `src/smbus/` with blocking and async `Bus` traits built on top of `embedded-hal-async::I2c`, including PEC support via `smbus-pec`. Comes with an extensive async test suite.
- **I2C target traits** (#26) — adds `src/i2c/target/` with blocking and async traits for I2C target-mode (slave) devices, including a 7-bit/10-bit address abstraction with full unit coverage.

### Quality & infrastructure
- **Improved test coverage** (#24) — new tests for `nvram`, `time::datetime`, `time::datetime_clock`, and `watchdog`; brings in `embedded-hal-mock` as a dev-dependency.
- **docs.rs all-features build** (#23) — `[package.metadata.docs.rs]` now builds with `chrono` and `defmt` enabled so the rendered docs include the feature-gated APIs.

### Repo hygiene
- LICENSE copyright refresh and AI attribution guidance (#25).

## New dependencies (embedded-mcu-hal)
- `embedded-hal-async = "1.0.0"` (runtime)
- `smbus-pec = "1.0"` (runtime, `no_std`)
- `embedded-hal-mock` (dev only)
- `tokio` with `macros, rt, time` (dev only, for async tests)

## `storage_bus`
No changes since `storage_bus_v0.1.0` — version stays at `0.1.0`.

## Verification
- `cargo build -p embedded-mcu-hal` — clean
- `cargo semver-checks check-release -p embedded-mcu-hal` — no semver update required (treated as minor, all additive)

## Release checklist (post-merge)
- [ ] Tag `embedded-mcu-hal-v0.3.0` on the merge commit
- [ ] `cargo publish -p embedded-mcu-hal`
